### PR TITLE
Fix missing color column and auto-migrate DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Run the application locally:
 ```bash
 python app.py
 ```
+
+The application will automatically upgrade the database schema if an older
+version is detected. If you previously ran the app before the `color` column was
+added, simply restart the app and it will migrate the existing database to the
+latest schema.

--- a/app.py
+++ b/app.py
@@ -28,6 +28,15 @@ def init_db():
     db.commit()
 
 
+def migrate_db():
+    """Ensure the database schema is up to date."""
+    db = get_db()
+    columns = [row['name'] for row in db.execute('PRAGMA table_info(habits)')]
+    if 'color' not in columns:
+        db.execute("ALTER TABLE habits ADD COLUMN color TEXT NOT NULL DEFAULT '#ffffff'")
+        db.commit()
+
+
 @app.route('/')
 def index():
     db = get_db()
@@ -39,4 +48,7 @@ if __name__ == '__main__':
     if not os.path.exists(DATABASE):
         with app.app_context():
             init_db()
+    else:
+        with app.app_context():
+            migrate_db()
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a small migration step that creates the `color` column if it is missing
- run migration when the database already exists
- document the migration behavior in the README
