### PR TITLE
Fix missing priority column in existing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ python app.py
 ```
 
 The application will automatically upgrade the database schema if an older
-version is detected. If you previously ran the app before the `color` column was
-added, simply restart the app and it will migrate the existing database to the
-latest schema.
+version is detected. If you previously ran the app before the `priority` or
+`color` columns were added, simply restart the app and it will migrate the
+existing database to the latest schema.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, g, request, redirect, url_for, session
 import sqlite3
 import os
-from db import init_db
+from db import init_db, migrate_db
 from werkzeug.security import generate_password_hash, check_password_hash
 from functools import wraps
 
@@ -12,6 +12,7 @@ app.secret_key = os.environ.get("SECRET_KEY", "dev")
 
 with app.app_context():
     init_db()
+    migrate_db()
 
 
 def get_db():

--- a/db.py
+++ b/db.py
@@ -52,3 +52,22 @@ def init_db():
     conn.commit()
     conn.close()
 
+
+def migrate_db():
+    """Upgrade existing tables to the latest schema."""
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    # Check existing columns in the habits table
+    cursor.execute('PRAGMA table_info(habits)')
+    columns = [row['name'] for row in cursor.fetchall()]
+
+    if 'priority' not in columns:
+        cursor.execute("ALTER TABLE habits ADD COLUMN priority TEXT NOT NULL DEFAULT 'low'")
+
+    if 'color' not in columns:
+        cursor.execute("ALTER TABLE habits ADD COLUMN color TEXT NOT NULL DEFAULT '#ffffff'")
+
+    conn.commit()
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add database migration helper to ensure `priority` and `color` columns exist
- call `migrate_db()` on startup
- update README about automatic upgrades
