### PR TITLE
Implement dynamic calendar view

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import os
 from db import init_db, migrate_db
 from werkzeug.security import generate_password_hash, check_password_hash
 from functools import wraps
+from datetime import datetime
+import calendar
 
 DATABASE = os.path.join(os.path.dirname(__file__), 'app.db')
 
@@ -72,7 +74,19 @@ def index():
         'SELECT name, color FROM habits WHERE user_id = ?',
         (session['user_id'],)
     ).fetchall()
-    return render_template('index.html', habits=habits)
+    now = datetime.now()
+    year = now.year
+    month = now.month
+    cal = calendar.Calendar()
+    weeks = cal.monthdayscalendar(year, month)
+    month_name = calendar.month_name[month]
+    return render_template(
+        'index.html',
+        habits=habits,
+        month_name=month_name,
+        year=year,
+        weeks=weeks,
+    )
 
 
 @app.route('/register', methods=['GET', 'POST'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-<h2 class="mb-4">Habit Tracker</h2>
+<h2 class="mb-4">{{ month_name }} {{ year }}</h2>
 
 <!-- Habit Legend Box -->
 <div class="mb-4">
@@ -13,13 +13,26 @@
   {% endfor %}
 </div>
 
-<!-- Calendar Grid -->
-<div class="d-flex flex-wrap gap-2 justify-content-start" style="max-width: 700px;">
-  {% for day in range(1, 31) %}
-    <div class="calendar-cell text-center border rounded shadow-sm p-3 bg-white" style="width: calc(100% / 7 - 8px);">
-      <strong>{{ day }}</strong>
-    </div>
+<!-- Weekday Header -->
+<div class="d-flex mb-2 text-center fw-semibold">
+  {% for day_name in ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] %}
+    <div class="flex-fill">{{ day_name }}</div>
   {% endfor %}
 </div>
+
+<!-- Calendar Grid -->
+{% for week in weeks %}
+  <div class="d-flex mb-2 text-center">
+    {% for day in week %}
+      {% if day == 0 %}
+        <div class="flex-fill p-3"></div>
+      {% else %}
+        <div class="calendar-cell flex-fill text-center border rounded shadow-sm p-3 bg-white">
+          <strong>{{ day }}</strong>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- include `datetime` and `calendar` modules
- compute the current month calendar in `index`
- render month/year and calendar grid in the homepage
