### PR TITLE
Implement month navigation and habit completion

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
 
-<h2 class="mb-4">{{ month_name }} {{ year }}</h2>
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <a class="btn btn-outline-primary" href="{{ url_for('calendar_view', year=prev_year, month=prev_month) }}">Prev</a>
+  <h2 class="mb-0">{{ month_name }} {{ year }}</h2>
+  <a class="btn btn-outline-primary" href="{{ url_for('calendar_view', year=next_year, month=next_month) }}">Next</a>
+</div>
 
 <!-- Habit Legend Box -->
 <div class="mb-4">
@@ -29,6 +33,21 @@
       {% else %}
         <div class="calendar-cell flex-fill text-center border rounded shadow-sm p-3 bg-white">
           <strong>{{ day }}</strong>
+          {% for habit in habits %}
+            {% set date_str = "%04d-%02d-%02d" % (year, month, day) %}
+            <form method="post" action="{{ url_for('complete') }}" class="mt-1">
+              <input type="hidden" name="habit_id" value="{{ habit['id'] }}">
+              <input type="hidden" name="date" value="{{ date_str }}">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="completed" id="h{{ habit['id'] }}_{{ day }}" onchange="this.form.submit()"
+                  {% if completed and (habit['id'] ~ '_' ~ date_str) in completed %}checked{% endif %}
+                  {% if is_future %}disabled{% endif %}>
+                <label class="form-check-label" for="h{{ habit['id'] }}_{{ day }}" style="color: {{ habit['color'] }};">
+                  {{ habit['name'] }}
+                </label>
+              </div>
+            </form>
+          {% endfor %}
         </div>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- add a `/calendar/<int:year>/<int:month>` route and redirect index
- track completed habit logs and pass extra parameters to template
- disable checkboxes for future months and add Prev/Next navigation
