### PR TITLE
Add track day page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
         <div class="flex-fill p-3"></div>
       {% else %}
         <div class="calendar-cell flex-fill text-center border rounded shadow-sm p-3 bg-white">
-          <strong>{{ day }}</strong>
+          <strong><a href="{{ url_for('track_day', year=year, month=month, day=day) }}">{{ day }}</a></strong>
           {% for habit in habits %}
             {% set date_str = "%04d-%02d-%02d" % (year, month, day) %}
             <form method="post" action="{{ url_for('complete') }}" class="mt-1">

--- a/templates/track_day.html
+++ b/templates/track_day.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-body p-4">
+        <h1 class="h4 mb-4 text-center fw-semibold">Habits for {{ date_str }}</h1>
+        <form method="post">
+          {% for habit in habits %}
+            <div class="form-check mb-2">
+              <input class="form-check-input" type="checkbox" name="habit_ids" value="{{ habit['id'] }}" id="habit{{ habit['id'] }}" {% if habit['id'] in completed %}checked{% endif %}>
+              <label class="form-check-label" for="habit{{ habit['id'] }}" style="color: {{ habit['color'] }};">
+                {{ habit['name'] }}
+              </label>
+            </div>
+          {% endfor %}
+          <button type="submit" class="btn btn-primary w-100 mt-3">Save</button>
+        </form>
+        <p class="mt-3 text-center"><a href="{{ url_for('calendar_view', year=year, month=month) }}" class="text-muted">Back</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new `track_day` route to view/edit daily completions
- link each calendar day to the track page
- create `track_day.html` to select multiple habits at once

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed3b872ec832890c791c617ff1b25