### PR TITLE
Display completed habit colors on calendar

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,10 +96,10 @@ def calendar_view(year, month):
     if next_month > 12:
         next_month = 1
         next_year += 1
-    # completed logs for month
+    # completed logs for month with associated colors
     logs = db.execute(
         """
-        SELECT habit_log.habit_id, habit_log.date
+        SELECT habit_log.habit_id, habits.color, habit_log.date
         FROM habit_log
         JOIN habits ON habit_log.habit_id = habits.id
         WHERE habits.user_id = ?
@@ -108,6 +108,13 @@ def calendar_view(year, month):
         """,
         (session['user_id'], str(year), f"{month:02d}")
     ).fetchall()
+
+    # Map day number to list of colors
+    day_colors = {}
+    for row in logs:
+        day = int(row['date'].split('-')[2])
+        day_colors.setdefault(day, []).append(row['color'])
+
     completed = {f"{row['habit_id']}_{row['date']}" for row in logs}
     return render_template(
         'index.html',
@@ -122,6 +129,7 @@ def calendar_view(year, month):
         next_year=next_year,
         next_month=next_month,
         completed=completed,
+        day_colors=day_colors,
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -72,3 +72,17 @@ body {
   background-color: #3e5ce8;
   border-color: #3e5ce8;
 }
+
+/* Colored dots for calendar completion indicators */
+.color-dots {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,13 @@
       {% else %}
         <div class="calendar-cell flex-fill text-center border rounded shadow-sm p-3 bg-white">
           <strong><a href="/track/{{ year }}/{{ month }}/{{ day }}">{{ day }}</a></strong>
+          {% if day_colors.get(day) %}
+            <div class="color-dots mt-2">
+              {% for color in day_colors[day] %}
+                <div class="color-dot" style="background-color: {{ color }};"></div>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- compute completion colors per day on the calendar
- show color dots for each completed habit
- style color indicators in CSS

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed66ef92c8328a6a6b6d294073aae