### PR TITLE
Update calendar grid layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -19,15 +19,18 @@ body {
   gap: 5px;
 }
 
-.calendar div {
+.calendar-day {
   background-color: #ffffff;
   border: 1px solid #e1e5ea;
   border-radius: 6px;
-  padding: 20px;
-  min-height: 60px;
-  text-align: right;
+  padding: 12px;
+  min-height: 100px;
   font-size: 0.8rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-align: right;
 }
 
 .legend {
@@ -74,11 +77,12 @@ body {
 }
 
 /* Colored dots for calendar completion indicators */
-.color-dots {
+.color-strip {
   display: flex;
-  justify-content: center;
+  flex-wrap: wrap;
   gap: 4px;
-  margin-top: 2px;
+  margin-top: 6px;
+  max-height: 40px;
 }
 
 .color-dot {

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,25 +25,23 @@
 </div>
 
 <!-- Calendar Grid -->
-{% for week in weeks %}
-  <div class="d-flex mb-2 text-center">
+<div class="calendar mb-2">
+  {% for week in weeks %}
     {% for day in week %}
       {% if day == 0 %}
-        <div class="flex-fill p-3"></div>
+        <div class="calendar-day"></div>
       {% else %}
-        <div class="calendar-cell flex-fill text-center border rounded shadow-sm p-3 bg-white">
+        <div class="calendar-day">
           <strong><a href="/track/{{ year }}/{{ month }}/{{ day }}">{{ day }}</a></strong>
-          {% if day_colors.get(day) %}
-            <div class="color-dots mt-2">
-              {% for color in day_colors[day] %}
-                <div class="color-dot" style="background-color: {{ color }};"></div>
-              {% endfor %}
-            </div>
-          {% endif %}
+          <div class="color-strip">
+            {% for color in day_colors.get(day, []) %}
+              <div class="color-dot" style="background-color: {{ color }};"></div>
+            {% endfor %}
+          </div>
         </div>
       {% endif %}
     {% endfor %}
-  </div>
-{% endfor %}
+  {% endfor %}
+</div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- refactor calendar markup to a single grid container
- add `.calendar-day` and `.color-strip` styling
- support wrapping color dots without stretching the cell
