### PR TITLE
Sort daily habits by priority

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -94,10 +94,24 @@ a:visited {
   gap: 4px;
   margin-top: 6px;
   max-height: 40px;
+  overflow: hidden;
+  align-items: center;
 }
 
 .color-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
+}
+
+.extra-badge {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: #6c757d;
+  color: #fff;
+  font-size: 0.65rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,9 +35,13 @@
           <div class="calendar-day">
             <strong>{{ day }}</strong>
             <div class="color-strip">
-              {% for color in day_colors.get(day, []) %}
-                <div class="color-dot" style="background-color: {{ color }};"></div>
+              {% set items = day_colors.get(day, []) %}
+              {% for habit in items[:3] %}
+                <div class="color-dot" style="background-color: {{ habit['color'] }};" title="{{ habit['name'] }}"></div>
               {% endfor %}
+              {% if items|length > 3 %}
+                <div class="extra-badge">+{{ items|length - 3 }}</div>
+              {% endif %}
             </div>
           </div>
         </a>


### PR DESCRIPTION
## Summary
- query habit priority for calendar days
- map priority names to a numeric ranking
- sort each day's habits by priority
- display only the top 3 habits per day and show a badge with hidden count
- add CSS for the badge and tweak calendar day style
