### PR TITLE
Add show password toggle to forms

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,11 @@
           </div>
           <div class="mb-3">
             <label for="password" class="form-label">Password</label>
-            <input type="password" class="form-control" name="password" required>
+            <input id="password" type="password" class="form-control" name="password" required>
+          </div>
+          <div class="form-check mb-3">
+            <input type="checkbox" class="form-check-input" id="togglePassword">
+            <label class="form-check-label" for="togglePassword">Show Password</label>
           </div>
           <button type="submit" class="btn btn-primary w-100">Login</button>
         </form>
@@ -20,4 +24,12 @@
     </div>
   </div>
 </div>
+<script>
+const toggle = document.getElementById('togglePassword');
+const password = document.getElementById('password');
+
+toggle.addEventListener('change', function () {
+  password.type = this.checked ? 'text' : 'password';
+});
+</script>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -12,7 +12,11 @@
           </div>
           <div class="mb-3">
             <label for="password" class="form-label">Password</label>
-            <input type="password" class="form-control" name="password" required>
+            <input id="password" type="password" class="form-control" name="password" required>
+          </div>
+          <div class="form-check mb-3">
+            <input type="checkbox" class="form-check-input" id="togglePassword">
+            <label class="form-check-label" for="togglePassword">Show Password</label>
           </div>
           <button type="submit" class="btn btn-success w-100">Register</button>
         </form>
@@ -20,4 +24,12 @@
     </div>
   </div>
 </div>
+<script>
+const toggle = document.getElementById('togglePassword');
+const password = document.getElementById('password');
+
+toggle.addEventListener('change', function () {
+  password.type = this.checked ? 'text' : 'password';
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable show/hide password on login form
- enable show/hide password on registration form

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684edf53aeb08328831346822433e3b8