### PR TITLE
Fix database init logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,8 @@ app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 
 with app.app_context():
-    init_db()
+    if not os.path.exists(DATABASE):
+        init_db()
     migrate_db()
 
 


### PR DESCRIPTION
## Summary
- only run `init_db()` if `app.db` is missing
