### PR TITLE
Add dashboard and planner pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,27 @@ def index():
     return redirect(url_for('calendar_view', year=now.year, month=now.month))
 
 
+@app.route('/dashboard')
+def dashboard():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    return render_template('dashboard.html')
+
+
+@app.route('/habit-tracker')
+def habit_tracker():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    return redirect(url_for('index'))
+
+
+@app.route('/planner')
+def planner():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    return render_template('planner.html')
+
+
 @app.route('/calendar/<int:year>/<int:month>')
 @login_required
 def calendar_view(year, month):
@@ -181,7 +202,7 @@ def login():
             session.clear()
             session['user_id'] = user['id']
             flash('Logged in successfully.', 'success')
-            return redirect(url_for('index'))
+            return redirect(url_for('dashboard'))
         flash('Invalid username or password', 'danger')
         return render_template('login.html')
     return render_template('login.html')

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,0 +1,8 @@
+.dashboard-gap {
+    height: 60vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
     <!-- Custom styles -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    {% block extra_css %}{% endblock %}
   </head>
   <body>
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+{% endblock %}
+{% block content %}
+<div class="d-flex flex-column align-items-center justify-content-center dashboard-gap">
+    <a href="{{ url_for('habit_tracker') }}" class="btn btn-primary btn-lg mb-3">Habit Tracker</a>
+    <a href="{{ url_for('planner') }}" class="btn btn-secondary btn-lg">Monthly Planner</a>
+</div>
+{% endblock %}

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Monthly Planner</h2>
+<p>This page is under construction.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/dashboard`, `/habit-tracker` and `/planner` routes
- create dashboard and planner templates
- add page-specific CSS file for dashboard
- redirect login to dashboard
- support custom page CSS in `base.html`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684fdeaf34008328803066c91699c94b